### PR TITLE
Make drag and drop of ingredients onto recipe undoable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,8 +109,8 @@ SET( Brewken_SRCS
     ${SRCDIR}/database/DatabaseSchema.cpp
     ${SRCDIR}/database/DatabaseSchemaHelper.cpp
     ${SRCDIR}/database/PropertySchema.cpp
-    ${SRCDIR}/database/TableSchemaConst.cpp
     ${SRCDIR}/database/TableSchema.cpp
+    ${SRCDIR}/database/TableSchemaConst.cpp
     ${SRCDIR}/EquipmentButton.cpp
     ${SRCDIR}/EquipmentEditor.cpp
     ${SRCDIR}/EquipmentListModel.cpp

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -128,6 +128,7 @@
 #include "StyleSortFilterProxyModel.h"
 #include "TimerMainDialog.h"
 #include "UndoableAddOrRemove.h"
+#include "UndoableAddOrRemoveList.h"
 #include "unit.h"
 #include "WaterDialog.h"
 #include "WaterEditor.h"
@@ -1422,12 +1423,20 @@ void MainWindow::droppedRecipeStyle(Style* style)
 // Well, aint this a kick in the pants. Apparently I can't template a slot
 void MainWindow::droppedRecipeFermentable(QList<Fermentable*>ferms)
 {
-   if ( ! recipeObs )
+   if ( ! recipeObs ) {
       return;
+   }
 
-   if ( tabWidget_ingredients->currentWidget() != fermentableTab )
+   if ( tabWidget_ingredients->currentWidget() != fermentableTab ) {
       tabWidget_ingredients->setCurrentWidget(fermentableTab);
-   Database::instance().addToRecipe(recipeObs, ferms);
+   }
+   this->doOrRedoUpdate(
+      newUndoableAddOrRemoveList(*this->recipeObs,
+                                 &Recipe::add<Fermentable>,
+                                 ferms,
+                                 &Recipe::remove<Fermentable>,
+                                 tr("Drop fermentables on a recipe"))
+   );
 }
 
 void MainWindow::droppedRecipeHop(QList<Hop*>hops)
@@ -1437,7 +1446,13 @@ void MainWindow::droppedRecipeHop(QList<Hop*>hops)
 
    if ( tabWidget_ingredients->currentWidget() != hopsTab )
       tabWidget_ingredients->setCurrentWidget(hopsTab);
-   Database::instance().addToRecipe(recipeObs, hops);
+   this->doOrRedoUpdate(
+      newUndoableAddOrRemoveList(*this->recipeObs,
+                                 &Recipe::add<Hop>,
+                                 hops,
+                                 &Recipe::remove<Hop>,
+                                 tr("Drop hops on a recipe"))
+   );
 }
 
 void MainWindow::droppedRecipeMisc(QList<Misc*>miscs)
@@ -1447,7 +1462,13 @@ void MainWindow::droppedRecipeMisc(QList<Misc*>miscs)
 
    if ( tabWidget_ingredients->currentWidget() != miscTab )
       tabWidget_ingredients->setCurrentWidget(miscTab);
-   Database::instance().addToRecipe(recipeObs, miscs);
+   this->doOrRedoUpdate(
+      newUndoableAddOrRemoveList(*this->recipeObs,
+                                 &Recipe::add<Misc>,
+                                 miscs,
+                                 &Recipe::remove<Misc>,
+                                 tr("Drop misc on a recipe"))
+   );
 }
 
 void MainWindow::droppedRecipeYeast(QList<Yeast*>yeasts)
@@ -1457,7 +1478,13 @@ void MainWindow::droppedRecipeYeast(QList<Yeast*>yeasts)
 
    if ( tabWidget_ingredients->currentWidget() != yeastTab )
       tabWidget_ingredients->setCurrentWidget(yeastTab);
-   Database::instance().addToRecipe(recipeObs, yeasts);
+   this->doOrRedoUpdate(
+      newUndoableAddOrRemoveList(*this->recipeObs,
+                                 &Recipe::add<Yeast>,
+                                 yeasts,
+                                 &Recipe::remove<Yeast>,
+                                 tr("Drop yeast on a recipe"))
+   );
 }
 
 void MainWindow::updateRecipeBatchSize()

--- a/src/UndoableAddOrRemoveList.h
+++ b/src/UndoableAddOrRemoveList.h
@@ -1,0 +1,138 @@
+/**
+ * UndoableAddOrRemoveList.h is part of Brewken, and is copyright the following authors 2021:
+ *   • Mattias Måhl <mattias@kejsarsten.com>
+ *   • Matt Young <mfsy@yahoo.com>
+ *
+ * Brewken is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Brewken is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+#ifndef UNDOABLE_ADD_OR_REMOVE_LIST_H
+#define UNDOABLE_ADD_OR_REMOVE_LIST_H
+#pragma once
+
+#include "Brewken.h" // For logging
+
+#include <QList>
+#include <QMetaType>
+#include <QString>
+#include <QUndoCommand>
+#include <QVariant>
+
+#include "model/Recipe.h"
+#include "model/Style.h"
+#include "StyleButton.h"
+
+/*!
+ * \class UndoableAddOrRemoveList
+ *
+ * \brief A version of \c that handles adding/removing lists of things to/from a recipe etc.
+ */
+template<class UU, class VV>
+class UndoableAddOrRemoveList : public QUndoCommand {
+public:
+   /*!
+    * \param updatee The object we are updating - eg recipe
+    * \param doer The method on the updatee to do the addition or removal.
+    *             This should return the object that needs to be passed in to the \c undoer method.
+    *             For certain classes - eg Fermentable, Hop - adding an object actually adds a new object which is
+    *             the "child" of the one passed in.  Thus adding a Fermentable to a recipe returns the new copy
+    *             ("child") Fermentable that was created; removing a Fermentable from a recipe returns its original
+    *             "parent" Fermentable.
+    * \param listToAddOrRemove The list of things we're adding or removing - eg fermentable
+    * \param undoer The method on the updatee to undo the addition or removal
+    * \param doCallback The method on MainWindow to call after doing/redoing the change - typically to update
+    *                   other display elements.  If null, no callback is made.
+    * \param undoCallback The method on MainWindow to call after undoing the change - typically to update
+    *                     other display elements.  If null, no callback is made.
+    * \param description Short text we can show on undo/redo menu to describe this update eg "Change Recipe Style"
+    * \param parent This is for grouping updates together.
+    */
+   UndoableAddOrRemoveList(UU & updatee,
+                       VV * (UU::*doer)(VV *),
+                       QList<VV *> listToAddOrRemove,
+                       VV * (UU::*undoer)(VV *),
+                       void (MainWindow::*doCallback)(VV *),
+                       void (MainWindow::*undoCallback)(VV *),
+                       QString const & description,
+                       QUndoCommand * parent = nullptr) : QUndoCommand(parent) {
+      // Parent class handles storing description and making it accessible to the undo stack etc - we just have to give
+      // it the text.
+      this->setText(description);
+
+      //
+      // We don't need to do anything in this class other than create an UndoableAddOrRemove object for each item in
+      // listToAddOrRemove.  Setting the parent field on a QUndoCommand makes that parent the owner, responsible for
+      // invoking, deleting, etc.  WE don't have to do anything more as the base class (QUndoCommand) does all the
+      // work.
+      //
+      for (auto ii : listToAddOrRemove) {
+         // Doesn't matter what description we pass in to these child objects as it will never be seen.  Might as well
+         // give them the same one as the parent/grouping object.
+         new UndoableAddOrRemove(updatee, doer, ii, undoer, doCallback, undoCallback, description, this);
+      }
+
+      return;
+   }
+
+   ~UndoableAddOrRemoveList() {
+      return;
+   }
+
+private:
+};
+
+
+/*!
+ * \brief Helper function that allows UndoableAddOrRemoveList to be instantiated with automatic template argument deduction.
+ *
+ *        (I thought this might not be necessary with the introduction of Class Template Argument Deduction in C++17,
+ *        but I think I must be missing something.)
+ */
+template<class UU, class VV> UndoableAddOrRemoveList<UU, VV> * newUndoableAddOrRemoveList(UU & updatee,
+                                                                                  VV * (UU::*doer)(VV *),
+                                                                                  QList<VV *> listToAddOrRemove,
+                                                                                  VV * (UU::*undoer)(VV *),
+                                                                                  void (MainWindow::*doCallback)(VV *),
+                                                                                  void (MainWindow::*undoCallback)(VV *),
+                                                                                  QString const & description,
+                                                                                  QUndoCommand * parent = nullptr) {
+   return new UndoableAddOrRemoveList<UU, VV>(updatee,
+                                          doer,
+                                          listToAddOrRemove,
+                                          undoer,
+                                          doCallback,
+                                          undoCallback,
+                                          description,
+                                          parent);
+}
+
+/*!
+ * \brief Helper function that allows UndoableAddOrRemoveList to be instantiated with automatic template argument deduction.
+ *
+ *        This is useful when there are no callbacks, otherwise caller has to do a static cast on null pointer
+ */
+template<class UU, class VV> UndoableAddOrRemoveList<UU, VV> * newUndoableAddOrRemoveList(UU & updatee,
+                                                                                  VV * (UU::*doer)(VV *),
+                                                                                  QList<VV *> listToAddOrRemove,
+                                                                                  VV * (UU::*undoer)(VV *),
+                                                                                  QString const & description,
+                                                                                  QUndoCommand * parent = nullptr) {
+   return new UndoableAddOrRemoveList<UU, VV>(updatee,
+                                          doer,
+                                          listToAddOrRemove,
+                                          undoer,
+                                          static_cast<void (MainWindow::*)(VV *)>(nullptr),
+                                          static_cast<void (MainWindow::*)(VV *)>(nullptr),
+                                          description,
+                                          parent);
+}
+
+#endif

--- a/src/database/TableSchemaConst.cpp
+++ b/src/database/TableSchemaConst.cpp
@@ -1,0 +1,68 @@
+/**
+ * database/TableSchemaConst.cpp is part of Brewken, and is copyright the following authors 2021:
+ *   • Matt Young <mfsy@yahoo.com>
+ *
+ * Brewken is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Brewken is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+#include "database/TableSchemaConst.h"
+
+namespace DatabaseConstants {
+   // These HAVE to be in the same order as they are listed in
+   // DatabaseConstants::DbTableId
+   QStringList const dbTableToName  = QStringList() <<
+      QString("none") <<  // need to handle the NOTABLE index
+      ktableSettings <<
+      ktableEquipment <<
+      ktableFermentable <<
+      ktableHop <<
+      ktableMisc <<
+      ktableStyle <<
+      ktableYeast <<
+      ktableWater <<
+      ktableMash <<
+      ktableMashStep <<
+//      ktableRecipe <<
+      QString(DatabaseNames::Tables::recipe) <<
+      ktableBrewnote <<
+      ktableInstruction <<
+      ktableSalt <<
+   // Now for BT internal tables
+      ktableBtEquipment <<
+      ktableBtFermentable <<
+      ktableBtHop <<
+      ktableBtMisc <<
+      ktableBtStyle <<
+      ktableBtYeast <<
+      ktableBtWater <<
+   // Now the in_recipe tables
+      ktableFermInRec <<
+      ktableHopInRec <<
+      ktableMiscInRec <<
+      ktableWaterInRec <<
+      ktableYeastInRec <<
+      ktableInsInRec <<
+      ktableSaltInRec <<
+   // child tables next
+      ktableEquipChildren <<
+      ktableFermChildren <<
+      ktableHopChildren <<
+      ktableMiscChildren <<
+      ktableRecChildren <<
+      ktableStyleChildren <<
+      ktableWaterChildren <<
+      ktableYeastChildren <<
+   // inventory tables last
+      ktableFermInventory <<
+      ktableHopInventory <<
+      ktableMiscInventory <<
+      ktableYeastInventory;
+}


### PR DESCRIPTION
Similar to https://github.com/Brewtarget/brewtarget/pull/585 but a bit less code.

Ignore the stuff about TableSchemaConst.cpp as it belongs in another commit.  (Forgot to add the file to git on the database branch.) 