### PR TITLE
Build fixes for Mac and older Linux

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1036,7 +1036,9 @@ void MainWindow::deleteSelected() {
 
    while (start.isValid() && active->type(start) == BtTreeItem::Type::FOLDER) {
       qDebug() << Q_FUNC_INFO << "Skipping over folder at row" << start.row();
-      start = start.siblingAtRow(start.row() + 1);
+      // Once all platforms are on Qt 5.11 or later, we can write:
+      // start = start.siblingAtRow(start.row() + 1);
+      start = start.sibling(start.row() + 1, start.column());
    }
 
    if (start.isValid()) {

--- a/src/json/JsonUtils.cpp
+++ b/src/json/JsonUtils.cpp
@@ -150,7 +150,7 @@ template QDebug & operator<<(QDebug & stream, boost::json::kind const knd);
 template QTextStream & operator<<(QTextStream & stream, boost::json::kind const knd);
 
 template<class S,
-         std::enable_if_t<(std::is_same<QDebug, S>::value || std::is_same<QTextStream, S>::value), bool> = true>
+         std::enable_if_t<(std::is_same<QDebug, S>::value || std::is_same<QTextStream, S>::value), bool> >
 S & operator<<(S & stream, boost::json::value const & val) {
    std::ostringstream output;
    output << val;


### PR DESCRIPTION
Older Linux uses older Qt, so we couldn't use `siblingAtRow()`.  Mac compiler is stricter than gcc and catches some errors that gcc lets through, in this case redeclaring a default parameter for a template.