### PR TITLE
Show mash steps etc in tree. Fix duplicate BrewNotes in tree.

### DIFF
--- a/src/model/EnumeratedBase.h
+++ b/src/model/EnumeratedBase.h
@@ -1,5 +1,5 @@
 /*======================================================================================================================
- * model/EnumeratedBase.h is part of Brewken, and is copyright the following authors 2023-2024:
+ * model/EnumeratedBase.h is part of Brewken, and is copyright the following authors 2023-2025:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewken is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
@@ -153,12 +153,12 @@ public:
    }
 
    /**
-    * \brief This is similarly needed by \c TreeModelBase -- but it needs a bit of a rethink
+    * \brief This is similarly needed by \c TreeModelBase
     */
-//   static QList<std::shared_ptr<Derived>> ownedBy(std::shared_ptr<Owner> owner) {
-//      // We already wrote all the logic in StepOwnerBase.
-//      return owner->steps();
-//   }
+   static QList<std::shared_ptr<Derived>> ownedBy(Owner const & owner) {
+      // We already wrote all the logic in StepOwnerBase.
+      return owner.steps();
+   }
 
    ObjectStore & doGetObjectStoreTypedInstance() const {
       return ObjectStoreTyped<Derived>::getInstance();

--- a/src/model/NamedEntity.h
+++ b/src/model/NamedEntity.h
@@ -62,13 +62,20 @@ class Recipe;
 //            careful about how we use them in look-ups.
 //
 #define AddPropertyName(property) namespace PropertyNames::NamedEntity { inline BtStringConst const property{#property}; }
-AddPropertyName(deleted)
-AddPropertyName(key)
-AddPropertyName(name)
+AddPropertyName(deleted   )
+AddPropertyName(key       )
+AddPropertyName(name      )
 AddPropertyName(subsidiary)
 #undef AddPropertyName
 //=========================================== End of property name constants ===========================================
 //======================================================================================================================
+
+// TODO: This needs fleshing out
+template<class NE>
+struct PropertyLookup {
+   NE::PropertyId propertyId;
+   TypeInfo const & typeInfo;
+};
 
 /**
  * \brief See \c NamedEntity::typeLookup.  This macro -- to include just after \c typeLookup in the class declaration of
@@ -129,6 +136,16 @@ class NamedEntity : public QObject {
    Q_CLASSINFO("version","1")
 
 public:
+
+   // TODO: This needs fleshing out
+   enum class PropertyId {
+      // Normally we would upper-case the first letter of an enum name, but here we want the same case as the property
+      // name, so we leave all lower-case
+      deleted   ,
+      key       ,
+      name      ,
+      subsidiary,
+   };
 
    /**
     * \brief Subclasses should provide their localised (ie translated) name via this static member function, so that

--- a/src/model/OwnedSet.h
+++ b/src/model/OwnedSet.h
@@ -1,5 +1,5 @@
 /*======================================================================================================================
- * model/OwnedSet.h is part of Brewken, and is copyright the following authors 2024:
+ * model/OwnedSet.h is part of Brewken, and is copyright the following authors 2024-2025:
  *   • Matt Young <mfsy@yahoo.com>
  *
  * Brewken is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
@@ -110,15 +110,6 @@ public:
 
    //! Non-virtual equivalent of isEqualTo
    bool doIsEqualTo(OwnedSet const & other) const {
-      //
-      // Check each object has the same number of items and they're all the same
-      //
-///      QList<std::shared_ptr<Item>> const myItems = this->items();
-///      QList<std::shared_ptr<Item>> const otherItems = other.items();
-///      return std::equal(   myItems.begin(),    myItems.end(),
-///                        otherItems.begin(), otherItems.end(),
-///                        [](std::shared_ptr<Item> const & lhs,
-///                           std::shared_ptr<Item> const & rhs) {return *lhs == *rhs;});
       return AUTO_LOG_COMPARE_FN(this, other, items);
    }
 
@@ -330,6 +321,11 @@ public:
       }
 
       return items;
+   }
+
+   //! An alternate way of calling \c items.  Used in \c trees/TreeModelBase.h
+   static QList<std::shared_ptr<Item>> ownedBy(Owner const & owner) {
+      return owner.items();
    }
 
    /**
@@ -558,8 +554,6 @@ public:
 
       // It's also a coding error if we're trying to swap a item with itself
       Q_ASSERT(lhs.key() != rhs.key());
-
-///      this->normaliseSeqNums();
 
       qDebug() <<
          Q_FUNC_INFO << "Swapping items" << lhs.seqNum() << "(#" << lhs.key() << ") and " << rhs.seqNum() << " (#" <<

--- a/src/trees/NamedEntityTreeModel.cpp
+++ b/src/trees/NamedEntityTreeModel.cpp
@@ -16,9 +16,9 @@
 #include "trees/NamedEntityTreeModel.h"
 
 TREE_MODEL_COMMON_CODE(Equipment   )
-TREE_MODEL_COMMON_CODE(Mash        )
-TREE_MODEL_COMMON_CODE(Boil        )
-TREE_MODEL_COMMON_CODE(Fermentation)
+TREE_MODEL_COMMON_CODE(Mash        , MashStep        )
+TREE_MODEL_COMMON_CODE(Boil        , BoilStep        )
+TREE_MODEL_COMMON_CODE(Fermentation, FermentationStep)
 TREE_MODEL_COMMON_CODE(Fermentable )
 TREE_MODEL_COMMON_CODE(Hop         )
 TREE_MODEL_COMMON_CODE(Misc        )

--- a/src/trees/NamedEntityTreeModel.h
+++ b/src/trees/NamedEntityTreeModel.h
@@ -18,11 +18,14 @@
 #pragma once
 
 #include "model/Boil.h"
+#include "model/BoilStep.h"
 #include "model/Equipment.h"
 #include "model/Fermentable.h"
 #include "model/Fermentation.h"
+#include "model/FermentationStep.h"
 #include "model/Hop.h"
 #include "model/Mash.h"
+#include "model/MashStep.h"
 #include "model/Misc.h"
 #include "model/Salt.h"
 #include "model/Style.h"
@@ -43,19 +46,19 @@ class FermentableTreeModel : public TreeModel, public TreeModelBase<FermentableT
    TREE_MODEL_COMMON_DECL(Fermentable)
 };
 
-class MashTreeModel : public TreeModel, public TreeModelBase<MashTreeModel, Mash> {
+class MashTreeModel : public TreeModel, public TreeModelBase<MashTreeModel, Mash, MashStep> {
    Q_OBJECT
-   TREE_MODEL_COMMON_DECL(Mash)
+   TREE_MODEL_COMMON_DECL(Mash, MashStep)
 };
 
-class BoilTreeModel : public TreeModel, public TreeModelBase<BoilTreeModel, Boil> {
+class BoilTreeModel : public TreeModel, public TreeModelBase<BoilTreeModel, Boil, BoilStep> {
    Q_OBJECT
-   TREE_MODEL_COMMON_DECL(Boil)
+   TREE_MODEL_COMMON_DECL(Boil, BoilStep)
 };
 
-class FermentationTreeModel : public TreeModel, public TreeModelBase<FermentationTreeModel, Fermentation> {
+class FermentationTreeModel : public TreeModel, public TreeModelBase<FermentationTreeModel, Fermentation, FermentationStep> {
    Q_OBJECT
-   TREE_MODEL_COMMON_DECL(Fermentation)
+   TREE_MODEL_COMMON_DECL(Fermentation, FermentationStep)
 };
 
 class HopTreeModel : public TreeModel, public TreeModelBase<HopTreeModel, Hop> {

--- a/src/trees/NamedEntityTreeView.cpp
+++ b/src/trees/NamedEntityTreeView.cpp
@@ -16,9 +16,9 @@
 #include "trees/NamedEntityTreeView.h"
 
 TREE_VIEW_COMMON_CODE(Equipment   )
-TREE_VIEW_COMMON_CODE(Mash        )
-TREE_VIEW_COMMON_CODE(Boil        )
-TREE_VIEW_COMMON_CODE(Fermentation)
+TREE_VIEW_COMMON_CODE(Mash        , MashStep        )
+TREE_VIEW_COMMON_CODE(Boil        , BoilStep        )
+TREE_VIEW_COMMON_CODE(Fermentation, FermentationStep)
 TREE_VIEW_COMMON_CODE(Fermentable )
 TREE_VIEW_COMMON_CODE(Hop         )
 TREE_VIEW_COMMON_CODE(Misc        )

--- a/src/trees/NamedEntityTreeView.h
+++ b/src/trees/NamedEntityTreeView.h
@@ -62,9 +62,10 @@ class MashTreeView : public TreeView,
                                          MashTreeModel,
                                          MashTreeSortFilterProxyModel,
                                          MashEditor,
-                                         Mash> {
+                                         Mash,
+                                         MashStep> {
    Q_OBJECT
-   TREE_VIEW_COMMON_DECL(Mash)
+   TREE_VIEW_COMMON_DECL(Mash, MashStep)
 };
 
 class BoilTreeView : public TreeView,
@@ -72,19 +73,21 @@ class BoilTreeView : public TreeView,
                                          BoilTreeModel,
                                          BoilTreeSortFilterProxyModel,
                                          BoilEditor,
-                                         Boil> {
+                                         Boil,
+                                         BoilStep> {
    Q_OBJECT
-   TREE_VIEW_COMMON_DECL(Boil)
+   TREE_VIEW_COMMON_DECL(Boil, BoilStep)
 };
 
 class FermentationTreeView : public TreeView,
-                     public TreeViewBase<FermentationTreeView,
-                                         FermentationTreeModel,
-                                         FermentationTreeSortFilterProxyModel,
-                                         FermentationEditor,
-                                         Fermentation> {
+                             public TreeViewBase<FermentationTreeView,
+                                                 FermentationTreeModel,
+                                                 FermentationTreeSortFilterProxyModel,
+                                                 FermentationEditor,
+                                                 Fermentation,
+                                                 FermentationStep> {
    Q_OBJECT
-   TREE_VIEW_COMMON_DECL(Fermentation)
+   TREE_VIEW_COMMON_DECL(Fermentation, FermentationStep)
 };
 
 class FermentableTreeView : public TreeView,

--- a/src/trees/RecipeTreeModel.cpp
+++ b/src/trees/RecipeTreeModel.cpp
@@ -53,9 +53,8 @@ void RecipeTreeModel::addBrewNoteSubTree(TreeNode & recipeNodeRaw,
    // ...so this cast should be safe.
    auto & recipeNode = static_cast<TreeItemNode<Recipe> &>(recipeNodeRaw);
 
-
-   int jj = 0;
-
+   qDebug() << Q_FUNC_INFO << "Adding" << brewNotes.size() << "BrewNotes for" << recipe;
+   int childNum = recipeNode.childCount();
    for (auto brewNote : brewNotes) {
       //
       // You might think we should just set recipeNodeIndex outside the loop or even pass it into this function as a
@@ -69,12 +68,12 @@ void RecipeTreeModel::addBrewNoteSubTree(TreeNode & recipeNodeRaw,
       QModelIndex recipeNodeIndex = this->createIndex(recipeChildNumber, 0, &recipeNodeRaw);
       // In previous insert loops, we ignore the error and soldier on. So we
       // will do that here too
-      if (!this->insertChild(recipeNode, recipeNodeIndex, jj, brewNote)) {
+      if (!this->insertChild(recipeNode, recipeNodeIndex, childNum, brewNote)) {
          qWarning() << Q_FUNC_INFO << "BrewNote insert failed";
          continue;
       }
       this->observeElement(brewNote);
-      ++jj;
+      ++childNum;
    }
    return;
 }
@@ -89,8 +88,8 @@ void RecipeTreeModel::addAncestoralTree(TreeNode & recipeNodeRaw,
    // ...so this cast should be safe.
    auto & recipeNode = static_cast<TreeItemNode<Recipe> &>(recipeNodeRaw);
 
-   // Now loop through the ancestors. The nature of the beast is nearest
-   // ancestors are first
+   // Now loop through the ancestors. The nature of the beast is nearest ancestors are first
+   qDebug() << Q_FUNC_INFO << "Adding" << ancestors.size() << "ancestors for" << recipe;
    int childNum = recipeNode.childCount();
    for (auto ancestor : ancestors) {
       // Comment in addBrewNoteSubTree() about indexes also applies here
@@ -136,22 +135,6 @@ void RecipeTreeModel::addSubTree(Recipe const & recipe,
 
    return;
 }
-
-void RecipeTreeModel::loadTreeModel() {
-   this->TreeModelBase::loadTreeModel();
-   // Set up the BrewNotes in the tree
-   auto recipes = ObjectStoreWrapper::getAllDisplayable<Recipe>();
-   for (auto recipe : recipes) {
-
-      QModelIndex recipeNodeIndex = this->findElement(recipe.get());
-      TreeNode * recipeNodeRaw = this->doTreeNode(recipeNodeIndex);
-      auto & recipeNode = static_cast<TreeItemNode<Recipe> &>(*recipeNodeRaw);
-
-      this->addSubTree(*recipe, recipeNode);
-   }
-   return;
-}
-
 
 bool RecipeTreeModel::showChild(QModelIndex child) const {
    TreeNode * node = this->treeNode(child);

--- a/src/trees/RecipeTreeModel.h
+++ b/src/trees/RecipeTreeModel.h
@@ -63,27 +63,24 @@ protected:
 private:
    //! \b flip the switch to show descendants
    void setShowChild(QModelIndex child, bool val);
-   void addAncestoralTree(TreeNode & recipeNode,
-                          int recipeChildNumber,
-                          Recipe const & recipe);
 
-   /**
-    * \brief Add brewnotes to a recipe as a subtree
-    * \param recurse
-    */
-   void addSubTree(Recipe const & recipe,
-                   TreeItemNode<Recipe> & recipeNode,
-                   bool const recurse = true);
-
-private:
    //! \brief convenience function to add brewnotes to a recipe as a subtree
    void addBrewNoteSubTree(TreeNode & recipeNodeRaw,
                            int recipeChildNumber,
                            Recipe const & recipe,
                            bool recurse = true);
 
-   //! \brief Override \c TreeModelBase::loadTreeModel()
-   void loadTreeModel();
+   void addAncestoralTree(TreeNode & recipeNode,
+                          int recipeChildNumber,
+                          Recipe const & recipe);
+
+   /**
+    * \brief Add BrewNotes and ancestors to a recipe as a sub-tree
+    * \param recurse
+    */
+   void addSubTree(Recipe const & recipe,
+                   TreeItemNode<Recipe> & recipeNode,
+                   bool const recurse = true);
 
 };
 

--- a/src/trees/TreeModelChangeGuard.cpp
+++ b/src/trees/TreeModelChangeGuard.cpp
@@ -15,6 +15,8 @@
  =====================================================================================================================*/
 #include "trees/TreeModelChangeGuard.h"
 
+#include <QDebug>
+
 TreeModelChangeGuard::TreeModelChangeGuard(TreeModelChangeType const changeType,
                                            TreeModel & model,
                                            QModelIndex const & parent,
@@ -23,6 +25,8 @@ TreeModelChangeGuard::TreeModelChangeGuard(TreeModelChangeType const changeType,
    m_changeType{changeType},
    m_model{model} {
    Q_ASSERT(first <= last);
+   qDebug() <<
+      Q_FUNC_INFO << "Prepare to" << this->m_changeType << ":" << first << "-" << last << "for parent" << parent;
    switch (this->m_changeType) {
       case TreeModelChangeType::InsertRows: this->m_model.beginInsertRows(parent, first, last); break;
       case TreeModelChangeType::RemoveRows: this->m_model.beginRemoveRows(parent, first, last); break;
@@ -32,6 +36,7 @@ TreeModelChangeGuard::TreeModelChangeGuard(TreeModelChangeType const changeType,
 }
 
 TreeModelChangeGuard::~TreeModelChangeGuard() {
+   qDebug() << Q_FUNC_INFO << "End of" << this->m_changeType;
    switch (this->m_changeType) {
       case TreeModelChangeType::InsertRows: this->m_model.endInsertRows(); break;
       case TreeModelChangeType::RemoveRows: this->m_model.endRemoveRows(); break;

--- a/src/trees/TreeModelChangeGuard.h
+++ b/src/trees/TreeModelChangeGuard.h
@@ -48,4 +48,21 @@ private:
    TreeModel & m_model;
 };
 
+/**
+ * \brief Convenience functions for logging
+ */
+/**@{*/
+template<class S> S & operator<<(S & stream, TreeModelChangeType const val);
+
+template<class S>
+S & operator<<(S & stream, TreeModelChangeType const val) {
+   switch (val) {
+      case TreeModelChangeType::InsertRows: stream << "insert rows"; break;
+      case TreeModelChangeType::RemoveRows: stream << "remove rows"; break;
+      // NB: No default clause, as we want compiler to warn us if we missed a case above
+   }
+   return stream;
+}
+/**@}*/
+
 #endif

--- a/src/trees/TreeNode.cpp
+++ b/src/trees/TreeNode.cpp
@@ -47,6 +47,20 @@
 #include "trees/RecipeTreeModel.h"
 #include "trees/TreeModel.h"
 
+namespace {
+   /**
+    * \brief Create a suitable display string for an optional double representing minutes
+    *
+    * \param units Whether to show the result in minutes or days
+    */
+   QString showOptionalMins(std::optional<double> minutes, Measurement::Unit const & units) {
+      if (minutes) {
+         return QString{"%1"}.arg(Measurement::displayAmount(Measurement::Amount{units.fromCanonical(*minutes), units}));
+      }
+      return "-";
+   }
+}
+
 TreeNode::TreeNode(TreeModel & model) :
    m_model{model} {
    return;
@@ -548,7 +562,29 @@ template<> QString TreeItemNode<Mash>::getToolTip() const {
    // First row -- total time
    body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td>")
            .arg(Mash::tr("Total time (mins)"))
-           .arg(Measurement::displayAmount(Measurement::Amount{this->m_underlyingItem->totalTime_mins(), Measurement::Units::minutes}) );
+           .arg(Measurement::displayAmount(Measurement::Amount{this->m_underlyingItem->totalTime_mins(),
+                                                               Measurement::Units::minutes}, 0));
+   body += "</table></body></html>";
+
+   return header + body;
+}
+
+template<> QString TreeItemNode<MashStep>::getToolTip() const {
+   // Do the style sheet first
+   QString header = "<html><head><style type=\"text/css\">";
+   header += Html::getCss(":/css/tooltip.css");
+   header += "</style></head>";
+
+   QString body   = "<body>";
+
+   body += QString("<div id=\"headerdiv\">");
+   body += QString("<table id=\"tooltip\">");
+   body += QString("<caption>%1</caption>")
+         .arg( this->m_underlyingItem->name() );
+   // First row -- step time
+   body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td>")
+           .arg(MashStep::tr("Step time (mins)"))
+           .arg(showOptionalMins(this->m_underlyingItem->stepTime_mins(), Measurement::Units::minutes));
 
    body += "</table></body></html>";
 
@@ -570,7 +606,30 @@ template<> QString TreeItemNode<Boil>::getToolTip() const {
    // First row -- total time
    body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td>")
            .arg(Boil::tr("Boil time (mins)"))
-           .arg(Measurement::displayAmount(Measurement::Amount{this->m_underlyingItem->boilTime_mins(), Measurement::Units::minutes}) );
+           .arg(Measurement::displayAmount(Measurement::Amount{this->m_underlyingItem->boilTime_mins(),
+                                                               Measurement::Units::minutes}, 0));
+
+   body += "</table></body></html>";
+
+   return header + body;
+}
+
+template<> QString TreeItemNode<BoilStep>::getToolTip() const {
+   // Do the style sheet first
+   QString header = "<html><head><style type=\"text/css\">";
+   header += Html::getCss(":/css/tooltip.css");
+   header += "</style></head>";
+
+   QString body   = "<body>";
+
+   body += QString("<div id=\"headerdiv\">");
+   body += QString("<table id=\"tooltip\">");
+   body += QString("<caption>%1</caption>")
+         .arg( this->m_underlyingItem->name() );
+   // First row -- step time
+   body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td>")
+           .arg(BoilStep::tr("Step time (mins)"))
+           .arg(showOptionalMins(this->m_underlyingItem->stepTime_mins(), Measurement::Units::minutes));
 
    body += "</table></body></html>";
 
@@ -591,8 +650,30 @@ template<> QString TreeItemNode<Fermentation>::getToolTip() const {
          .arg( this->m_underlyingItem->name() );
    // First row -- description
    body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td>")
-           .arg(Fermentation::tr("Total time (mins)"))
+           .arg(Fermentation::tr("Description"))
            .arg(this->m_underlyingItem->description());
+
+   body += "</table></body></html>";
+
+   return header + body;
+}
+
+template<> QString TreeItemNode<FermentationStep>::getToolTip() const {
+   // Do the style sheet first
+   QString header = "<html><head><style type=\"text/css\">";
+   header += Html::getCss(":/css/tooltip.css");
+   header += "</style></head>";
+
+   QString body   = "<body>";
+
+   body += QString("<div id=\"headerdiv\">");
+   body += QString("<table id=\"tooltip\">");
+   body += QString("<caption>%1</caption>")
+         .arg( this->m_underlyingItem->name() );
+   // First row -- step time
+   body += QString("<tr><td class=\"left\">%1</td><td class=\"value\">%2</td>")
+           .arg(FermentationStep::tr("Step time (days)"))
+           .arg(showOptionalMins(this->m_underlyingItem->stepTime_mins(), Measurement::Units::days));
 
    body += "</table></body></html>";
 

--- a/src/trees/TreeNode.h
+++ b/src/trees/TreeNode.h
@@ -44,9 +44,15 @@
  *        compile-time mapping from object type to show which class belongs in which tree.  The rule here is that things
  *        belong in their own tree (eg Equipment is in Equipment tree) unless there's a specialisation that says
  *        otherwise.
+ *
+ *        If a secondary item \c FooBar is omitted from this list, we'll get compile errors along the lines of `invalid
+ *        use of incomplete type ‘struct TreeNodeTraits<FooBar, FooBar>’`.
  */
-template <class NE> struct TreeTypeDeducer           { using TreeType = NE    ; };
-template<>          struct TreeTypeDeducer<BrewNote> { using TreeType = Recipe; };
+template <class NE> struct TreeTypeDeducer                   { using TreeType = NE          ; };
+template<>          struct TreeTypeDeducer<BrewNote        > { using TreeType = Recipe      ; };
+template<>          struct TreeTypeDeducer<MashStep        > { using TreeType = Mash        ; };
+template<>          struct TreeTypeDeducer<BoilStep        > { using TreeType = Boil        ; };
+template<>          struct TreeTypeDeducer<FermentationStep> { using TreeType = Fermentation; };
 
 class TreeModel;
 

--- a/src/trees/TreeNodeBase.h
+++ b/src/trees/TreeNodeBase.h
@@ -329,7 +329,7 @@ public:
     */
    ChildPtrTypes child(int number) const {
       if constexpr (IsSubstantiveVariant<ChildPtrTypes>) {
-         Q_ASSERT(number < this->m_children.size());
+         Q_ASSERT(number < static_cast<int>(this->m_children.size()));
          return this->m_children.at(number);
       } else {
          // For the moment, it is simpler to allow calls to this function even when there can be no children.  We just

--- a/src/trees/TreeView.cpp
+++ b/src/trees/TreeView.cpp
@@ -42,6 +42,12 @@ TreeView::TreeView(QWidget * parent) :
    // This shows the little arrow next to folders so you can see whether they are expanded or not
    this->setRootIsDecorated(true);
 
+   // In QTreeView "this property should only be set to true if it is guaranteed that all items in the view has the same
+   // height. This enables the view to do some optimizations."
+   this->setUniformRowHeights(true);
+
+   this->setAnimated(true);
+
    this->setDragEnabled(true);
    this->setAcceptDrops(true);
    this->setDropIndicatorShown(true);
@@ -125,5 +131,11 @@ void TreeView::keyPressEvent(QKeyEvent * event) {
          return;
    }
    QTreeView::keyPressEvent(event);
+   return;
+}
+
+void TreeView::rowsInserted(QModelIndex const & parent, int start, int end) {
+   qDebug() << Q_FUNC_INFO << "Rows" << start << "-" << end << "added to" << parent;
+   this->QTreeView::rowsInserted(parent, start, end);
    return;
 }

--- a/src/trees/TreeView.h
+++ b/src/trees/TreeView.h
@@ -98,6 +98,15 @@ public:
    //! \brief Overrides \c QTreeView::keyPressEvent.  Catches a key stroke in a tree
    virtual void keyPressEvent(QKeyEvent * event) override;
 
+protected slots:
+   /**
+    * \brief Override \c QTreeView::rowsInserted so we can add logging
+    *
+    *        You might think we could do a similar thing for \c QTreeView::rowsRemoved.  However, that function is not
+    *        virtual, so we cannot.
+    */
+   virtual void rowsInserted(QModelIndex const & parent, int start, int end) override;
+
 protected:
    QPoint dragStart;
 

--- a/src/utils/EnumMapping.h
+++ b/src/utils/EnumMapping.h
@@ -1,0 +1,56 @@
+/*======================================================================================================================
+ * utils/EnumMapping.h is part of Brewken, and is copyright the following authors 2021-2025:
+ *   • Matt Young <mfsy@yahoo.com>
+ *
+ * Brewken is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Brewken is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ =====================================================================================================================*/
+#ifndef UTILS_ENUMMAPPING_H
+#define UTILS_ENUMMAPPING_H
+#pragma once
+
+/**
+ * \brief Pairs an enum value \c key with \c value of type \c T (which must be default constructable).
+ */
+template<typename T> struct EnumKeyValue {
+   int     key;
+   T       value;
+
+   /**
+    * \brief Need a default constructor for storing in a vector
+    */
+   EnumKeyValue() :
+      key{-1},
+      value{} {
+      return;
+   };
+
+   /**
+    * \brief Standard constructor, which we need to declare explicitly in order to have the templated version below
+    */
+   EnumKeyValue(int const key, T const value) :
+      key{key},
+      value{value} {
+      return;
+   };
+
+   /**
+    * \brief Convenience constructor for creating \c EnumAndItsString using strongly typed enums (ie those declared as
+    *        "enum class")
+    */
+   template<typename E>
+   EnumKeyValue(E const key, T const value) : EnumKeyValue{static_cast<int>(key), value} {
+      return;
+   }
+
+};
+
+#endif

--- a/src/utils/EnumStringMapping.h
+++ b/src/utils/EnumStringMapping.h
@@ -25,6 +25,7 @@
 #include <QVector>
 
 #include "Logging.h"
+#include "utils/EnumMapping.h"
 #include "utils/TypeLookup.h"
 
 /**


### PR DESCRIPTION
Includes fix for https://github.com/Brewtarget/brewtarget/issues/971 and initial work on showing mash steps, boil steps etc in the trees on the left hand side of the main window.